### PR TITLE
make http client pluggable

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mitch000001/go-hbci/element"
 	"github.com/mitch000001/go-hbci/message"
 	"github.com/mitch000001/go-hbci/segment"
+	"github.com/mitch000001/go-hbci/transport"
 )
 
 // Config defines the basic configuration needed for a Client to work.
@@ -20,6 +21,7 @@ type Config struct {
 	PIN         string `json:"pin"`
 	URL         string `json:"url"`
 	HBCIVersion int    `json:"hbci_version"`
+	Transport   transport.Transport
 }
 
 func (c Config) hbciVersion() (segment.HBCIVersion, error) {
@@ -64,7 +66,15 @@ func New(config Config) (*Client, error) {
 		}
 		hbciVersion = version
 	}
-	d := dialog.NewPinTanDialog(bankID, url, config.AccountID, hbciVersion)
+	dcfg := dialog.Config{
+		BankID:      bankID,
+		HBCIURL:     url,
+		UserID:      config.AccountID,
+		HBCIVersion: hbciVersion,
+		Transport:   config.Transport,
+	}
+
+	d := dialog.NewPinTanDialog(dcfg)
 	d.SetPin(config.PIN)
 	client := &Client{
 		config:       config,

--- a/dialog/dialog_test.go
+++ b/dialog/dialog_test.go
@@ -244,10 +244,14 @@ func TestPinTanDialogInit(t *testing.T) {
 }
 
 func newTestPinTanDialog(transport *mockHTTPSTransport) *PinTanDialog {
-	url := "http://localhost"
-	clientID := "12345"
-	bankID := domain.BankID{CountryCode: 280, ID: "10000000"}
-	d := NewPinTanDialog(bankID, url, clientID, segment.HBCI220)
+	cfg := Config{
+		BankID:      domain.BankID{CountryCode: 280, ID: "10000000"},
+		HBCIURL:     "http://localhost",
+		UserID:      "12345",
+		HBCIVersion: segment.HBCI220,
+	}
+
+	d := NewPinTanDialog(cfg)
 	d.SetPin("abcde")
 	d.SetClientSystemID("xyz")
 	d.transport = transport

--- a/dialog/pin_tan_dialog_examples_test.go
+++ b/dialog/pin_tan_dialog_examples_test.go
@@ -2,18 +2,18 @@ package dialog_test
 
 import (
 	"github.com/mitch000001/go-hbci/domain"
-	"github.com/mitch000001/go-hbci/segment"
 )
 import "github.com/mitch000001/go-hbci/dialog"
 
 func ExamplePinTanDialog() {
-	url := "https://bank.de/hbci"
-	userId := "100000000"
-	blz := "1000000"
-	bankId := domain.BankID{
-		CountryCode: 280,
-		ID:          blz,
+	cfg := dialog.Config{
+		HBCIURL: "https://bank.de/hbci",
+		UserID:  "100000000",
+		BankID: domain.BankID{
+			CountryCode: 280,
+			ID:          "1000000",
+		},
 	}
-	d := dialog.NewPinTanDialog(bankId, url, userId, segment.HBCI220)
+	d := dialog.NewPinTanDialog(cfg)
 	d.SetPin("12345")
 }

--- a/transport/https/https.go
+++ b/transport/https/https.go
@@ -67,6 +67,14 @@ func New() *HTTPSTransport {
 	}
 }
 
+// NewNonDefault returns a HTTPSTransport which uses the given http.Client to
+// perform requests to the HBCO server
+func NewNonDefault(h *http.Client) transport.Transport {
+	return &HTTPSTransport{
+		HTTPClient: h,
+	}
+}
+
 // A HTTPSTransport implements transport.Transport and performs request over HTTPS
 type HTTPSTransport struct {
 	HTTPClient *http.Client


### PR DESCRIPTION
I am so happy to find a go HCBI implementation so I can ditch that Java thing from my architecture :-D

One thing though: I need to plug in a different http.Client as the default one. As far as I can tell some code changes are needed to do that. I quickly applied them and it works for me.

I modified the Config struct and I am not sure if this breaks the config JSON parsing in some way though.