### PR TITLE
Parse purpose fields as string lists.

### DIFF
--- a/swift/element.go
+++ b/swift/element.go
@@ -111,12 +111,12 @@ type CustomFieldTag struct {
 	TransactionID      int
 	BookingText        string
 	PrimanotenNumber   string
-	Purpose            string
+	Purpose            []string
 	BankID             string
 	AccountID          string
 	Name               string
 	MessageKeyAddition int
-	Purpose2           string
+	Purpose2           []string
 }
 
 var customFieldTagFieldKeys = [][]byte{
@@ -187,7 +187,7 @@ func (c *CustomFieldTag) Unmarshal(value []byte) error {
 		case bytes.HasPrefix(fieldKey, []byte{'?', '1', '0'}):
 			c.PrimanotenNumber = fieldValue
 		case bytes.HasPrefix(fieldKey, []byte{'?', '2'}):
-			c.Purpose += fieldValue
+			c.Purpose = append(c.Purpose, fieldValue)
 		case bytes.HasPrefix(fieldKey, []byte{'?', '3', '0'}):
 			c.BankID = fieldValue
 		case bytes.HasPrefix(fieldKey, []byte{'?', '3', '1'}):
@@ -203,7 +203,7 @@ func (c *CustomFieldTag) Unmarshal(value []byte) error {
 			}
 			c.MessageKeyAddition = messageKeyAddition
 		case bytes.HasPrefix(fieldKey, []byte{'?', '6'}):
-			c.Purpose2 += fieldValue
+			c.Purpose2 = append(c.Purpose2, fieldValue)
 		default:
 			internal.Debug.Printf("Unmarshal CustomFieldTag: unknown fieldKey: %s\n", fieldKey)
 		}

--- a/swift/element_test.go
+++ b/swift/element_test.go
@@ -13,12 +13,12 @@ func TestCustomFieldTagUnmarshal(t *testing.T) {
 		TransactionID:      123,
 		BookingText:        "ABC",
 		PrimanotenNumber:   "xyz",
-		Purpose:            "ahhhjj",
+		Purpose:            []string{"ahh", "hjj"},
 		BankID:             "1000",
 		AccountID:          "56",
 		Name:               "Max Muster",
 		MessageKeyAddition: 99,
-		Purpose2:           "uuz4",
+		Purpose2:           []string{"uu", "z4"},
 	}
 
 	tag := &CustomFieldTag{}

--- a/swift/mt940.go
+++ b/swift/mt940.go
@@ -65,8 +65,8 @@ func (m *MT940) AccountTransactions() []domain.AccountTransaction {
 			transaction.BankID = descr.BankID
 			transaction.AccountID = descr.AccountID
 			transaction.Name = descr.Name
-			transaction.Purpose = descr.Purpose
-			transaction.Purpose2 = descr.Purpose2
+			transaction.Purpose = strings.Join(descr.Purpose, " ")
+			transaction.Purpose2 = strings.Join(descr.Purpose2, " ")
 			transaction.TransactionID = descr.TransactionID
 		}
 		transactions = append(transactions, transaction)


### PR DESCRIPTION
Messages usually contain multiple purpose fields that are currently simply
concatenated. This loses the spacing information between different fields
in the message. This change preserves the string list during parsing and
passes a space-separated list back to the account transaction code.

Actually it would make sense to return the lists to the callers of the account
transaction code as well, but that would be a breaking API change.