### PR TITLE
Fix SWIFT transactions: error unmarshaling MT940

### DIFF
--- a/swift/mt940.go
+++ b/swift/mt940.go
@@ -263,8 +263,6 @@ func (t *TransactionTag) Unmarshal(value []byte) error {
 				t.CurrencyKind = string(runes[1:])
 			} else if len(runes) == 1 {
 				t.DebitCreditIndicator = string(runes)
-			} else {
-				return fmt.Errorf("%T: Malformed marshaled value", t)
 			}
 			break
 		}


### PR DESCRIPTION
Hi, 
this fixes 

`error unmarshaling SWIFT transactions: error unmarshaling MT940: *swift.TransactionTag: Malformed marshaled value`

for something like
`:61:221214C115,83NMSCNONREF`.

According to Gesamtdok_HBCI22.pdf page 753 these values are not mandatory and `len(runes)` can be 0.


